### PR TITLE
Align TTS output folder with config

### DIFF
--- a/tts.py
+++ b/tts.py
@@ -2,15 +2,13 @@ import os
 import json
 import requests
 from dotenv import load_dotenv
-from pathlib import Path
+from config import AUDIO_DIR
 
 # Load environment variables from .env
 load_dotenv()
 
 # Constants
 ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY")
-AUDIO_DIR = Path("audio")
-AUDIO_DIR.mkdir(exist_ok=True)
 CHUNK_SIZE = 1024
 
 if not ELEVENLABS_API_KEY:


### PR DESCRIPTION
## Summary
- rely on `AUDIO_DIR` from `config.py`
- remove local audio path setup in `tts.py`

## Testing
- `python -m py_compile tts.py`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb1b3a40483219ab60c9390c7dd3c