### PR TITLE
Fix script error handling

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -600,6 +600,7 @@ Provide the output in JSON format with the following structure:
 
     except Exception as e:
         logger.error(f"Unhandled error: {e}")
+        return None
 def select_voice(script_text):
     """
     Selects the most appropriate voice from the VOICES dictionary based on the complete script.


### PR DESCRIPTION
## Summary
- return `None` after logging unhandled exceptions in `generate_video_script`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683fb1b57ef4832189c161a5b43ee8c1